### PR TITLE
change command line api

### DIFF
--- a/cloud_compile.py
+++ b/cloud_compile.py
@@ -58,8 +58,10 @@ async def post(output_path, file_name, compressed, use_clang, llc_args, opt_args
                     output = body['data']
                     if output_path == '-':
                         sys.stdout.buffer.write(base64.b64decode(output))
-                    with open(output_path, 'wb') as fd:
-                        fd.write(base64.b64decode(output))
+                        sys.stdout.flush()
+                    else:
+                        with open(output_path, 'wb') as fd:
+                            fd.write(base64.b64decode(output))
                 else:
                     raise Exception("Failed response")
     except Exception as e:

--- a/cloud_compile.py
+++ b/cloud_compile.py
@@ -52,7 +52,7 @@ async def post(output_path, file_name, compressed, use_clang, llc_args, opt_args
                 body = json.loads(body)
 
                 if body['std_out']['data']:
-                    print("Stdout: " + body['std_out']['data'])
+                    print("Stdout: " + body['std_out']['data'], file=sys.stderr)
 
                 if resp.status == 200:
                     output = body['data']
@@ -63,7 +63,7 @@ async def post(output_path, file_name, compressed, use_clang, llc_args, opt_args
                 else:
                     raise Exception("Failed response")
     except Exception as e:
-        print("Unable to post {} to lambda due to {}.".format(file_name, e.__class__))
+        print("Unable to post {} to lambda due to {}.".format(file_name, e.__class__), file=sys.stderr)
 
 
 async def main(source, compressed, use_clang, output, llc_args, opt_args, clang_args, target):
@@ -76,7 +76,7 @@ async def main(source, compressed, use_clang, output, llc_args, opt_args, clang_
         files = glob.glob(os.path.join(source, "*.bc"))
 
     await asyncio.gather(*[post(output, file_name, compressed, use_clang, llc_args, opt_args, clang_args, target) for file_name in files])
-    print("Finished requests to lambda.")
+    print("Finished requests to lambda.", file=sys.stderr)
 
 def checkParams():
     source = ''
@@ -117,7 +117,7 @@ def checkParams():
 
         source = args.file
     except Exception as e:
-        print("Error parsing arguments: {}.".format(e.__class__))
+        print("Error parsing arguments: {}.".format(e.__class__), file=sys.stderr)
         sys.exit(2)
 
 

--- a/cloud_compile.py
+++ b/cloud_compile.py
@@ -56,6 +56,8 @@ async def post(output_path, file_name, compressed, use_clang, llc_args, opt_args
 
                 if resp.status == 200:
                     output = body['data']
+                    if output_path == '-':
+                        sys.stdout.buffer.write(base64.b64decode(output))
                     with open(output_path, 'wb') as fd:
                         fd.write(base64.b64decode(output))
                 else:


### PR DESCRIPTION
This change allows reading input from stdin and writing to stdout (I am in the process of integrating this into clang and plan to directly pipe input into the python client without using an indirect file). Also removed the output directory and for the user to explicitly specify output file path.

With the changes you can do something like this
```bash
cat hello.bc | python cloud_compile.py - -o - > x.o
```
Which is not very useful for interactive use, but will allow interaction with clang easier.